### PR TITLE
The directive can now indicate dirtiness. Can also raise the ng-change event.

### DIFF
--- a/angular-pagedown.js
+++ b/angular-pagedown.js
@@ -19,8 +19,9 @@ angular.module("ui.pagedown", [])
 
     return {
         restrict: "E",
+        require: 'ngModel',
         scope: {
-            content: "=",
+            ngModel: "=",
             placeholder: "@",
             showPreview: "@",
             help: "&",
@@ -30,7 +31,12 @@ angular.module("ui.pagedown", [])
             previewClass: "=?",
             previewContent: "=?"
         },
-        link: function (scope, element, attrs) {
+        link: function (scope, element, attrs, ngModel) {
+
+            scope.changed = function() {
+                ngModel.$setDirty();
+                scope.$parent.$eval(attrs.ngChange);
+            };
 
             var editorUniqueId;
 
@@ -50,7 +56,8 @@ angular.module("ui.pagedown", [])
                 '<div>' +
                     '<div class="wmd-panel">' +
                         '<div id="wmd-button-bar-' + editorUniqueId + '"></div>' +
-                        '<textarea id="wmd-input-' + editorUniqueId + '" placeholder="' + placeholder + '" ng-model="content"' +
+                        '<textarea id="wmd-input-' + editorUniqueId + '" placeholder="' + placeholder + '" ng-model="ngModel"' +
+                        ' ng-change="changed()"' +
                         ' rows="' + editorRows + '" ' + (scope.editorClass ? 'ng-class="editorClass"' : 'class="wmd-input"') + '>' +
                         '</textarea>' +
                     '</div>' +

--- a/angular-pagedown.js
+++ b/angular-pagedown.js
@@ -79,15 +79,16 @@ angular.module("ui.pagedown", [])
                     handler: help
                 });
 
+
+                var editorElement = angular.element(document.getElementById("wmd-input-" + editorUniqueId));
+
                 converter.hooks.chain("postConversion", function (text) {
-                    scope.changed();
+                    ngModel.$setViewValue(editorElement.val());
 
                     // update
                     scope.previewContent = text;
                     return text;
                 });
-
-                var editorElement = angular.element(document.getElementById("wmd-input-" + editorUniqueId));
 
 
                 // add watch for content

--- a/angular-pagedown.js
+++ b/angular-pagedown.js
@@ -82,6 +82,8 @@ angular.module("ui.pagedown", [])
 
                 var editorElement = angular.element(document.getElementById("wmd-input-" + editorUniqueId));
 
+                editorElement.val(scope.ngModel);
+
                 converter.hooks.chain("postConversion", function (text) {
                     ngModel.$setViewValue(editorElement.val());
 

--- a/angular-pagedown.js
+++ b/angular-pagedown.js
@@ -33,6 +33,12 @@ angular.module("ui.pagedown", [])
             },
             link: function (scope, element, attrs, ngModel) {
 
+                scope.changed = function () {
+                    ngModel.$setDirty();
+                    scope.$parent.$eval(attrs.ngChange);
+                };
+
+
                 var editorUniqueId;
 
                 if (attrs.id == null) {
@@ -52,6 +58,7 @@ angular.module("ui.pagedown", [])
                     '<div class="wmd-panel">' +
                     '<div id="wmd-button-bar-' + editorUniqueId + '"></div>' +
                     '<textarea id="wmd-input-' + editorUniqueId + '" placeholder="' + placeholder + '" ng-model="ngModel"' +
+                    ' ng-change="changed()"' +
                     ' rows="' + editorRows + '" ' + (scope.editorClass ? 'ng-class="editorClass"' : 'class="wmd-input"') + '>' +
                     '</textarea>' +
                     '</div>' +
@@ -73,21 +80,14 @@ angular.module("ui.pagedown", [])
                 });
 
                 converter.hooks.chain("postConversion", function (text) {
+                    scope.changed();
+
                     // update
                     scope.previewContent = text;
                     return text;
                 });
 
                 var editorElement = angular.element(document.getElementById("wmd-input-" + editorUniqueId));
-
-
-                scope.$watch(function () {
-                    return editorElement[0].value;
-                }, function (newVal) {
-                    ngModel.$setViewValue(newVal);
-                    ngModel.$setDirty();
-                    scope.$parent.$eval(attrs.ngChange);
-                });
 
 
                 // add watch for content

--- a/angular-pagedown.js
+++ b/angular-pagedown.js
@@ -6,159 +6,163 @@ var mdExtraOptions = {
 
 // adapted from http://stackoverflow.com/a/20957476/940030
 angular.module("ui.pagedown", [])
-.directive("pagedownEditor", ['$compile', '$timeout', '$window', '$q', function ($compile, $timeout, $window, $q) {
-    var nextId = 0;
-    var converter = Markdown.getSanitizingConverter();
-    Markdown.Extra.init(converter, mdExtraOptions);
+    .directive("pagedownEditor", ['$compile', '$timeout', '$window', '$q', function ($compile, $timeout, $window, $q) {
+        var nextId = 0;
+        var converter = Markdown.getSanitizingConverter();
+        Markdown.Extra.init(converter, mdExtraOptions);
 
-    converter.hooks.chain("preBlockGamut", function (text, rbg) {
-        return text.replace(/^ {0,3}""" *\n((?:.*?\n)+?) {0,3}""" *$/gm, function (whole, inner) {
-            return "<blockquote>" + rbg(inner) + "</blockquote>\n";
+        converter.hooks.chain("preBlockGamut", function (text, rbg) {
+            return text.replace(/^ {0,3}""" *\n((?:.*?\n)+?) {0,3}""" *$/gm, function (whole, inner) {
+                return "<blockquote>" + rbg(inner) + "</blockquote>\n";
+            });
         });
-    });
 
-    return {
-        restrict: "E",
-        require: 'ngModel',
-        scope: {
-            ngModel: "=",
-            placeholder: "@",
-            showPreview: "@",
-            help: "&",
-            insertImage: "&",
-            editorClass: "=?",
-            editorRows: "@",
-            previewClass: "=?",
-            previewContent: "=?"
-        },
-        link: function (scope, element, attrs, ngModel) {
+        return {
+            restrict: "E",
+            require: 'ngModel',
+            scope: {
+                ngModel: "=",
+                placeholder: "@",
+                showPreview: "@",
+                help: "&",
+                insertImage: "&",
+                editorClass: "=?",
+                editorRows: "@",
+                previewClass: "=?",
+                previewContent: "=?"
+            },
+            link: function (scope, element, attrs, ngModel) {
 
-            scope.changed = function() {
-                ngModel.$setDirty();
-                scope.$parent.$eval(attrs.ngChange);
-            };
+                var editorUniqueId;
 
-            var editorUniqueId;
+                if (attrs.id == null) {
+                    editorUniqueId = nextId++;
+                } else {
+                    editorUniqueId = attrs.id;
+                }
 
-            if (attrs.id == null) {
-                editorUniqueId = nextId++;
-            } else {
-                editorUniqueId = attrs.id;
-            }
+                // just hide the preview, we still need it for "onPreviewRefresh" hook
+                var previewHiddenStyle = scope.showPreview == "false" ? "display: none;" : "";
 
-            // just hide the preview, we still need it for "onPreviewRefresh" hook
-            var previewHiddenStyle = scope.showPreview == "false" ? "display: none;" : "";
+                var placeholder = attrs.placeholder || "";
+                var editorRows = attrs.editorRows || "10";
 
-            var placeholder = attrs.placeholder || "";
-            var editorRows = attrs.editorRows || "10";
-
-            var newElement = $compile(
-                '<div>' +
+                var newElement = $compile(
+                    '<div>' +
                     '<div class="wmd-panel">' +
-                        '<div id="wmd-button-bar-' + editorUniqueId + '"></div>' +
-                        '<textarea id="wmd-input-' + editorUniqueId + '" placeholder="' + placeholder + '" ng-model="ngModel"' +
-                        ' ng-change="changed()"' +
-                        ' rows="' + editorRows + '" ' + (scope.editorClass ? 'ng-class="editorClass"' : 'class="wmd-input"') + '>' +
-                        '</textarea>' +
+                    '<div id="wmd-button-bar-' + editorUniqueId + '"></div>' +
+                    '<textarea id="wmd-input-' + editorUniqueId + '" placeholder="' + placeholder + '" ng-model="ngModel"' +
+                    ' rows="' + editorRows + '" ' + (scope.editorClass ? 'ng-class="editorClass"' : 'class="wmd-input"') + '>' +
+                    '</textarea>' +
                     '</div>' +
                     '<div id="wmd-preview-' + editorUniqueId + '" style="' + previewHiddenStyle + '"' +
                     ' ' + (scope.previewClass ? 'ng-class="previewClass"' : 'class="wmd-panel wmd-preview"') + '>' +
                     '</div>' +
-                '</div>')(scope);
+                    '</div>')(scope);
 
-            // html() doesn't work
-            element.append(newElement);
+                // html() doesn't work
+                element.append(newElement);
 
-            var help = angular.isFunction(scope.help) ? scope.help : function () {
-                // redirect to the guide by default
-                $window.open("http://daringfireball.net/projects/markdown/syntax", "_blank");
-            };
+                var help = angular.isFunction(scope.help) ? scope.help : function () {
+                    // redirect to the guide by default
+                    $window.open("http://daringfireball.net/projects/markdown/syntax", "_blank");
+                };
 
-            var editor = new Markdown.Editor(converter, "-" + editorUniqueId, {
-                handler: help
-            });
-
-            converter.hooks.chain("postConversion", function(text) {
-                // update
-                scope.previewContent = text;
-                return text;
-            });
-
-            var editorElement = angular.element(document.getElementById("wmd-input-" + editorUniqueId));
-
-            // add watch for content
-            if(scope.showPreview != "false") {
-                scope.$watch('content', function () {
-                    editor.refreshPreview();
+                var editor = new Markdown.Editor(converter, "-" + editorUniqueId, {
+                    handler: help
                 });
-            }
-            editor.hooks.chain("onPreviewRefresh", function() {
-                // wire up changes caused by user interaction with the pagedown controls
-                // and do within $apply
-                $timeout(function() {
-                    scope.content = editorElement.val();
+
+                converter.hooks.chain("postConversion", function (text) {
+                    // update
+                    scope.previewContent = text;
+                    return text;
                 });
-            });
 
-            if (angular.isFunction(scope.insertImage)) {
-                editor.hooks.set("insertImageDialog", function(callback) {
-                    // expect it to return a promise or a url string
-                    var result = scope.insertImage();
+                var editorElement = angular.element(document.getElementById("wmd-input-" + editorUniqueId));
 
-                    // Note that you cannot call the callback directly from the hook; you have to wait for the current scope to be exited.
-                    // https://code.google.com/p/pagedown/wiki/PageDown#insertImageDialog
-                    $timeout(function() {
-                        if (!result) {
-                            // must be null to indicate failure
-                            callback(null);
-                        } else {
-                            // safe way to handle either string or promise
-                            $q.when(result).then(
-                                function success(imgUrl) {
-                                    callback(imgUrl);
-                                },
-                                function error(reason) {
-                                    callback(null);
-                                }
-                            );
-                        }
+
+                scope.$watch(function () {
+                    return editorElement[0].value;
+                }, function (newVal) {
+                    ngModel.$setViewValue(newVal);
+                    ngModel.$setDirty();
+                    scope.$parent.$eval(attrs.ngChange);
+                });
+
+
+                // add watch for content
+                if (scope.showPreview != "false") {
+                    scope.$watch('content', function () {
+                        editor.refreshPreview();
                     });
-
-                    return true;
+                }
+                editor.hooks.chain("onPreviewRefresh", function () {
+                    // wire up changes caused by user interaction with the pagedown controls
+                    // and do within $apply
+                    $timeout(function () {
+                        scope.content = editorElement.val();
+                    });
                 });
-            }
 
-            editor.run();
-        }
-    }
-}])
-.directive("pagedownViewer", ['$compile', '$sce', function ($compile, $sce) {
-    var converter = Markdown.getSanitizingConverter();
-    Markdown.Extra.init(converter, mdExtraOptions);
+                if (angular.isFunction(scope.insertImage)) {
+                    editor.hooks.set("insertImageDialog", function (callback) {
+                        // expect it to return a promise or a url string
+                        var result = scope.insertImage();
 
-    return {
-        restrict: "E",
-        scope: {
-            content: "="
-        },
-        link: function (scope, element, attrs) {
-            var run = function run() {
-                if (!scope.content) {
-                    scope.sanitizedContent = '';
-                    return;
+                        // Note that you cannot call the callback directly from the hook; you have to wait for the current scope to be exited.
+                        // https://code.google.com/p/pagedown/wiki/PageDown#insertImageDialog
+                        $timeout(function () {
+                            if (!result) {
+                                // must be null to indicate failure
+                                callback(null);
+                            } else {
+                                // safe way to handle either string or promise
+                                $q.when(result).then(
+                                    function success(imgUrl) {
+                                        callback(imgUrl);
+                                    },
+                                    function error(reason) {
+                                        callback(null);
+                                    }
+                                );
+                            }
+                        });
+
+                        return true;
+                    });
                 }
 
-                scope.sanitizedContent = $sce.trustAsHtml(converter.makeHtml(scope.content));
-            };
-
-            scope.$watch("content", run);
-
-            run();
-
-            var newElementHtml = "<p ng-bind-html='sanitizedContent'></p>";
-            var newElement = $compile(newElementHtml)(scope);
-
-            element.append(newElement);
+                editor.run();
+            }
         }
-    }
-}]);
+    }])
+    .directive("pagedownViewer", ['$compile', '$sce', function ($compile, $sce) {
+        var converter = Markdown.getSanitizingConverter();
+        Markdown.Extra.init(converter, mdExtraOptions);
+
+        return {
+            restrict: "E",
+            scope: {
+                content: "="
+            },
+            link: function (scope, element, attrs) {
+                var run = function run() {
+                    if (!scope.content) {
+                        scope.sanitizedContent = '';
+                        return;
+                    }
+
+                    scope.sanitizedContent = $sce.trustAsHtml(converter.makeHtml(scope.content));
+                };
+
+                scope.$watch("content", run);
+
+                run();
+
+                var newElementHtml = "<p ng-bind-html='sanitizedContent'></p>";
+                var newElement = $compile(newElementHtml)(scope);
+
+                element.append(newElement);
+            }
+        }
+    }]);


### PR DESCRIPTION
Related to this issue:

https://github.com/kennyki/angular-pagedown/issues/8

Changed the pagedownEditor directive’s content attribute to ngModel attribute and requires ngModel in order to raise the $setDirty whenever the user changes the textarea.

Allows pagedownEditor directive users to add ng-change expression. ng-change requires ng-model, hence also the need to change the content attribute to ngModel attribute.